### PR TITLE
OPTM-36 Updated network_info_plus_windows to version 1.0.2 in pubspec.lock

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -365,7 +365,7 @@ packages:
       name: network_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   package_config:
     dependency: transitive
     description:


### PR DESCRIPTION
As discussed in PJ-ODS-2021/P2P-Task#3 we do not want to delete the `pubspec.lock` file.
This updates only the relevant package version in the lock file to fix the flutter windows natives.

Once version 1.0.2 of the network_info_plus plugin is available we should update `pubspec.yaml`.