### PR TITLE
OPTM-79 Exclude generated folders for static code analysis.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,12 @@
 include: package:pedantic/analysis_options.1.11.0.yaml
 
 analyzer:
+  exclude:
+    - linux/**
+    - windows/**
+    - macos/**
+    - ios/**
+    - android/**
   plugins:
     - dart_code_metrics
 


### PR DESCRIPTION
- Exclude linux/ windows/ macos/ ios/ android/

OPTM-79 #close