### PR TITLE
OPTM-55 Use own crdt library instead of the flutter crdt library

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lww_crdt"]
+	path = lww_crdt
+	url = ../lww_crdt.git

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,7 @@ analyzer:
     - macos/**
     - ios/**
     - android/**
+    - lww_crdt/**
   plugins:
     - dart_code_metrics
 

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -14,7 +14,7 @@ class TaskListScreen extends StatelessWidget {
         Provider.of<ChangeCallbackNotifier<TaskListService>>(context)
             .callbackProvider;
 
-    final futureBuilder = FutureBuilder<List<Task>>(
+    final futureBuilder = FutureBuilder<Iterable<Task>>(
       initialData: [],
       future: taskListService.tasks,
       builder: (context, snapshot) {
@@ -27,7 +27,11 @@ class TaskListScreen extends StatelessWidget {
           );
         }
 
-        return _buildTaskList(context, taskListService, snapshot.data!);
+        return _buildTaskList(
+          context,
+          taskListService,
+          snapshot.data!.toList(),
+        );
       },
     );
 

--- a/lib/services/task_list_service.dart
+++ b/lib/services/task_list_service.dart
@@ -22,9 +22,17 @@ class TaskListService with LogMixin, ChangeCallbackProvider {
     this._syncService,
   );
 
-  Future<List<Task>> get tasks async {
-    return (await _taskListCrdt).values.toList();
-  }
+  Future<Iterable<Task>> get tasks async => (await _taskListCrdt).values;
+
+  Future<Iterable<TaskRecord>> get taskRecords async => (await _taskListCrdt)
+      .records
+      .values
+      .where((record) => !record.isDeleted)
+      .map((record) => TaskRecord(
+            record.value!,
+            record.clock.node,
+            DateTime.fromMillisecondsSinceEpoch(record.clock.timestamp),
+          ));
 
   Future upsert(Task task) async {
     l.info('Upsert task ${task.toJson()}');
@@ -116,4 +124,12 @@ class TaskListService with LogMixin, ChangeCallbackProvider {
 
     return crdt;
   }
+}
+
+class TaskRecord {
+  final Task task;
+  final String peerId;
+  final DateTime timestamp;
+
+  const TaskRecord(this.task, this.peerId, this.timestamp);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,13 +162,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
-  crdt:
-    dependency: "direct main"
-    description:
-      name: crdt
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.2"
   crypto:
     dependency: transitive
     description:
@@ -408,6 +401,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  lww_crdt:
+    dependency: "direct main"
+    description:
+      path: lww_crdt
+      relative: true
+    source: path
+    version: "1.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,11 +35,13 @@ dependencies:
   json_annotation: ^4.0.1
   flutter_slidable: ^0.6.0
   uuid: ^3.0.4
-  crdt: ^4.0.2
   sembast: ^3.1.0+2
   sembast_web: ^2.0.0+2
   collection: ^1.15.0
   flutter_simple_dependency_injection: ^2.0.0
+
+  lww_crdt:
+    path: lww_crdt
 
   pedantic: ^1.11.0
 

--- a/test/services/task_list_merge_test.dart
+++ b/test/services/task_list_merge_test.dart
@@ -98,6 +98,34 @@ void main() {
         [task1, task2].toSet());
   });
 
+  test('crdt update less recent task', () async {
+    final task1 = Task(title: 'task1');
+    await devices[0].taskListService.upsert(task1);
+    final task2 = Task(
+        id: (await devices[0].taskListService.tasks).first.id, title: 'task2');
+    await devices[1].taskListService.upsert(task2);
+
+    await devices[0]
+        .taskListService
+        .mergeCrdtJson(await devices[1].taskListService.crdtToJson());
+    expect(await devices[1].taskListService.tasks, [task2]);
+    expect(await devices[0].taskListService.tasks, [task2]);
+  });
+
+  test('crdt keep more recent task', () async {
+    final task1 = Task(title: 'task1');
+    await devices[0].taskListService.upsert(task1);
+    final task2 = Task(
+        id: (await devices[0].taskListService.tasks).first.id, title: 'task2');
+    await devices[1].taskListService.upsert(task2);
+
+    await devices[1]
+        .taskListService
+        .mergeCrdtJson(await devices[0].taskListService.crdtToJson());
+    expect(await devices[0].taskListService.tasks, [task1]);
+    expect(await devices[1].taskListService.tasks, [task2]);
+  });
+
   tearDown(() async {
     await Future.wait(devices.map((device) => device.close()));
   });

--- a/test/services/task_list_merge_test.dart
+++ b/test/services/task_list_merge_test.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:crdt/crdt.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:p2p_task/models/task.dart';
+import 'package:p2p_task/services/identity_service.dart';
+import 'package:p2p_task/services/sync_service.dart';
+import 'package:p2p_task/services/task_list_service.dart';
+import 'package:p2p_task/utils/key_value_repository.dart';
+import 'package:sembast/sembast.dart';
+import 'package:sembast/sembast_memory.dart';
+
+class DeviceTaskList {
+  final Database database;
+  final KeyValueRepository keyValueRepository;
+  final IdentityService identityService;
+  final SyncService syncService;
+  final TaskListService taskListService;
+
+  DeviceTaskList(this.database, this.keyValueRepository, this.identityService,
+      this.syncService, this.taskListService);
+
+  static Future<DeviceTaskList> create(
+      {DatabaseFactory? databaseFactory,
+      String? databasePath,
+      String? name}) async {
+    final database = await (databaseFactory ?? newDatabaseFactoryMemory())
+        .openDatabase(databasePath ?? sembastInMemoryDatabasePath);
+    final keyValueRepository = KeyValueRepository(database);
+    final identityService = IdentityService(keyValueRepository);
+    if (name != null) await identityService.setName(name);
+    final syncService = SyncService(keyValueRepository);
+    final taskListService =
+        TaskListService(keyValueRepository, identityService, syncService);
+    return DeviceTaskList(database, keyValueRepository, identityService,
+        syncService, taskListService);
+  }
+
+  Future<void> close() {
+    return database.close();
+  }
+}
+
+void main() {
+  var devices = <DeviceTaskList>[];
+
+  setUp(() async {
+    devices = [
+      await DeviceTaskList.create(name: 'device1'),
+      await DeviceTaskList.create(name: 'device2'),
+    ];
+  });
+
+  test('distinct task lists', () async {
+    final task1 = Task(title: 'task1');
+    final task2 = Task(title: 'task2');
+    await devices[0].taskListService.upsert(task1);
+    await devices[1].taskListService.upsert(task2);
+
+    expect(await devices[0].taskListService.tasks, [task1]);
+    expect(await devices[1].taskListService.tasks, [task2]);
+  });
+
+  test('crdt merge tasks unordered', () async {
+    final task1 = Task(title: 'task1');
+    final task2 = Task(title: 'task2');
+    await devices[0].taskListService.upsert(task1);
+    await devices[1].taskListService.upsert(task2);
+
+    await devices[0]
+        .taskListService
+        .mergeCrdtJson(await devices[1].taskListService.crdtToJson());
+    expect(await devices[1].taskListService.tasks, [task2]);
+    expect((await devices[0].taskListService.tasks).toSet(),
+        [task1, task2].toSet());
+  });
+
+  test('crdt merge clock drift', () async {
+    // The crdt library throws a ClockDriftException when trying to merge with a Hlc timestamp that is more than 1 minute in the future.
+
+    final task1 = Task(title: 'task1');
+    final task2 = Task(title: 'task2');
+    await devices[0].taskListService.upsert(task1);
+    await devices[1].taskListService.upsert(task2);
+
+    final Map<String, dynamic> device1Tasks =
+        jsonDecode(await devices[1].taskListService.crdtToJson());
+    expect(device1Tasks.length, 1);
+    final Map<String, dynamic> deviceTask1 = device1Tasks.values.first;
+    expect(deviceTask1.containsKey('hlc'), true);
+    deviceTask1['hlc'] = Hlc.fromDate(
+            DateTime.now().add(Duration(minutes: 10)), device1Tasks.keys.first)
+        .toJson();
+
+    await devices[0].taskListService.mergeCrdtJson(jsonEncode(device1Tasks));
+    expect(await devices[1].taskListService.tasks, [task2]);
+    expect((await devices[0].taskListService.tasks).toSet(),
+        [task1, task2].toSet());
+  });
+
+  tearDown(() async {
+    await Future.wait(devices.map((device) => device.close()));
+  });
+}


### PR DESCRIPTION
**Important**
The library is in a git submodule and integrated with a local package dependency, you need to run
```sh
git submodule init
git submodule update
```
after pulling this branch.

You also need to delete the database file (`p2p_task.db`) because the task list storage format is incompatible.