### PR TITLE
Fix code metrics warnings

### DIFF
--- a/lib/config/app_module.dart
+++ b/lib/config/app_module.dart
@@ -19,6 +19,7 @@ import 'package:sembast/sembast.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AppModule {
+  // ignore: long-method
   Future<void> initialize(Injector injector) async {
     injector.dispose();
     injector = Injector();

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -67,6 +67,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
       await databaseService.deleteStore(StoreRefNames.settings.value);
       await syncService.setInterval(await syncService.interval);
       await identityService.setName(name!);
+      // Used to force a rebuild of the entire settings screen.
+      // Otherwise, we would need to invoke the callback notifier
+      // of every service that a child widget is dependent on.
+      // ignore: no-empty-block
       setState(() {});
     }
   }

--- a/lib/screens/setup/dependencies_provider.dart
+++ b/lib/screens/setup/dependencies_provider.dart
@@ -50,6 +50,7 @@ class _DependenciesProviderState extends State<DependenciesProvider> {
     );
   }
 
+  // ignore: long-method
   Widget _buildProviders(BuildContext context, Widget child) {
     return MultiProvider(
       providers: [

--- a/lib/utils/platform_database_factory.dart
+++ b/lib/utils/platform_database_factory.dart
@@ -25,6 +25,7 @@ class PlatformDatabaseFactory extends DatabaseFactory {
   bool get hasStorage => !_inMemory;
 
   @override
+  // ignore: long-parameter-list
   Future<Database> openDatabase(
     String path, {
     int? version,

--- a/lib/widgets/yes_no_dialog.dart
+++ b/lib/widgets/yes_no_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class YesNoDialog extends StatelessWidget {
+  // ignore: long-parameter-list
   static Future<bool?> show(
     BuildContext context, {
     String? title,


### PR DESCRIPTION
OPTM-88, OPTM-89

The warnings are intentionally ignored.

The _long-method_ warnings are ignored in
- app_module.dart
- dependencies_provider.dart

because in both cases similar things are done in almost all lines. In the former file initializing the dependency graph for our app and in latter providing those dependencies into the widget tree. One could possibly reduce the lines either by grouping some parts or extracting every dependency into their own methods but I argue it would more likely reduce the readability in this case.

The _long-parameter-list_ warnings are ignored in
- platform_database_factory.dart
- yes_no_dialog.dart

because in the former file the class extends `DatabaseFactory` and overrides a method. Therefore, we can't change the method declaration. The latter, on the other hand, is a UI component and it's very common in Flutter to have a multitude of options for `Widget`s. (As a comparison see also the Flutter method `showGeneralDialog`, which even has a lot more options.)

The last case in the `SettingsScreen` widget is explained in an accompanying comment.

To my surprise those were the only warnings, thus I instantly fixed them all. (For that reason, this includes OPTM-89.)