### PR TITLE
OPTM-114 Device list not reloading when changed in the background

### DIFF
--- a/lib/services/change_callback_notifier.dart
+++ b/lib/services/change_callback_notifier.dart
@@ -6,12 +6,12 @@ class ChangeCallbackNotifier<T extends ChangeCallbackProvider>
   final T callbackProvider;
 
   ChangeCallbackNotifier(this.callbackProvider) {
-    callbackProvider.changeCallback = () => notifyListeners();
+    callbackProvider.addChangeCallback(notifyListeners);
   }
 
   @override
   void dispose() {
-    callbackProvider.changeCallback = null;
+    callbackProvider.removeChangeCallback(notifyListeners);
     super.dispose();
   }
 }

--- a/lib/services/change_callback_provider.dart
+++ b/lib/services/change_callback_provider.dart
@@ -1,7 +1,19 @@
 class ChangeCallbackProvider {
-  Function()? changeCallback;
+  final _changeCallbacks = <void Function()>[];
+
+  void addChangeCallback(void Function() callback) {
+    _changeCallbacks.add(callback);
+  }
+
+  bool removeChangeCallback(void Function() callback) {
+    return _changeCallbacks.remove(callback);
+  }
+
+  void clearChangeCallbacks() {
+    _changeCallbacks.clear();
+  }
 
   void invokeChangeCallback() {
-    if (changeCallback != null) changeCallback!();
+    _changeCallbacks.forEach((callback) => callback());
   }
 }

--- a/lib/viewmodels/device_list_viewmodel.dart
+++ b/lib/viewmodels/device_list_viewmodel.dart
@@ -36,6 +36,7 @@ class DeviceListViewModel with LogMixin {
 
   DeviceListViewModel(this._peerInfoService, this._peerService) {
     loadDevices();
+    _peerInfoService.addChangeCallback(loadDevices);
   }
 
   void loadDevices() {
@@ -126,6 +127,7 @@ class DeviceListViewModel with LogMixin {
   }
 
   void dispose() {
+    _peerInfoService.removeChangeCallback(loadDevices);
     peerInfos.dispose();
   }
 }

--- a/lib/viewmodels/device_list_viewmodel.dart
+++ b/lib/viewmodels/device_list_viewmodel.dart
@@ -53,7 +53,6 @@ class DeviceListViewModel with LogMixin {
       peerInfo,
       peerInfo.locations.first,
     );
-    loadDevices();
   }
 
   void handleQrCodeRead(String qrContent) async {
@@ -78,17 +77,14 @@ class DeviceListViewModel with LogMixin {
       peerInfo,
       peerInfo.locations.first,
     );
-    loadDevices();
   }
 
   void syncWithPeer(PeerInfo peer, {PeerLocation? location}) async {
     await _peerService.syncWithPeer(peer, location: location);
-    loadDevices();
   }
 
   void upsert(PeerInfo peer) async {
     await _peerInfoService.upsert(peer);
-    loadDevices();
   }
 
   void sendIntroductionMessageToPeer(
@@ -108,7 +104,6 @@ class DeviceListViewModel with LogMixin {
       logger.warning('could not send delete peer message - $e');
     } finally {
       await _peerInfoService.remove(peer);
-      loadDevices();
     }
   }
 

--- a/test/services/change_callback_provider_test.dart
+++ b/test/services/change_callback_provider_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:p2p_task/services/change_callback_provider.dart';
+
+void main() {
+  group('ChangeCallbackProvider', () {
+    test('should invoke change callback', () async {
+      final provider = ChangeCallbackProvider();
+      final completer = Completer<bool>();
+      final callback = () => completer.complete(true);
+      provider.addChangeCallback(callback);
+      provider.invokeChangeCallback();
+      expect(completer.isCompleted, true);
+      expect(await completer.future, true);
+    });
+
+    test('should not invoke change after removing it', () {
+      final provider = ChangeCallbackProvider();
+      final completer = Completer<bool>();
+      final callback = () => completer.complete(true);
+      provider.addChangeCallback(callback);
+      provider.removeChangeCallback(callback);
+      provider.invokeChangeCallback();
+      expect(completer.isCompleted, false);
+    });
+
+    test('should invoke multiple callbacks', () async {
+      final provider = ChangeCallbackProvider();
+      final completers = [
+        for (var i = 0; i < 10; i++) Completer<bool>(),
+      ];
+      final callbacks = completers
+          .map((completer) => () => completer.complete(true))
+          .toList();
+      callbacks.forEach(provider.addChangeCallback);
+
+      provider.invokeChangeCallback();
+      completers.forEach((completer) => expect(completer.isCompleted, true));
+      expect(
+        await Future.wait(completers.map((completer) => completer.future)),
+        completers.map((_) => true).toList(),
+      );
+    });
+
+    test('should invoke multiple callbacks remove some', () async {
+      final provider = ChangeCallbackProvider();
+      final completers = [
+        for (var i = 0; i < 10; i++) Completer<bool>(),
+      ];
+      final callbacks = completers
+          .map((completer) => () => completer.complete(true))
+          .toList();
+      callbacks.forEach(provider.addChangeCallback);
+      for (var i = 0; i < callbacks.length; i++) {
+        if (i.isEven) provider.removeChangeCallback(callbacks[i]);
+      }
+
+      provider.invokeChangeCallback();
+
+      for (var i = 0; i < completers.length; i++) {
+        final completer = completers[i];
+        if (i.isEven) {
+          expect(completer.isCompleted, false);
+        } else {
+          expect(completer.isCompleted, true);
+          expect(await completer.future, true);
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
Added ability to add multiple listeners to ChangeCallbackProvider. Added callback to reload devices on change callback in DeviceListViewModel.

The device list will now automatically refresh when there are changes to the peer infos.